### PR TITLE
Add result count display and update pagination

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       </div>
     </div>
   </div>
+  <div id="result-info"></div>
   <div id="drop-container">載入中...</div>
   </div> <!-- /.container -->
 

--- a/js/main.js
+++ b/js/main.js
@@ -18,6 +18,16 @@ let currentPage = 0;
 let currentKeyword = '';
 let currentOnlyMatchedDrops = false;
 
+function updateResultInfo() {
+  const total = currentEntries.length;
+  const loaded = document.querySelectorAll('#drop-container .monster-card').length;
+  const remaining = Math.max(0, total - loaded);
+  const info = document.getElementById('result-info');
+  if (info) {
+    info.textContent = `總數 ${total}，已載入 ${loaded}，未載入 ${remaining}`;
+  }
+}
+
 function renderCards(entries, keyword = '', onlyMatchedDrops = false, append = false) {
   const minLv = parseInt(document.getElementById('min-lv').value) || 0;
   const maxLv = parseInt(document.getElementById('max-lv').value) || Infinity;
@@ -388,9 +398,13 @@ function renderCards(entries, keyword = '', onlyMatchedDrops = false, append = f
 function renderNextPage() {
   const start = currentPage * PAGE_SIZE;
   const entries = currentEntries.slice(start, start + PAGE_SIZE);
-  if (entries.length === 0) return;
+  if (entries.length === 0) {
+    updateResultInfo();
+    return;
+  }
   renderCards(entries, currentKeyword, currentOnlyMatchedDrops, start > 0);
   currentPage++;
+  updateResultInfo();
 }
 
 function refresh() {
@@ -447,6 +461,7 @@ function refresh() {
 
   window.scrollTo({ top: 0 });
   lastScrollTop = 0;
+  updateResultInfo();
 
   if (currentEntries.length === 0) {
     renderCards([], keyword, onlyMatchedDrops);

--- a/main.css
+++ b/main.css
@@ -248,14 +248,20 @@ mark {
 }
 
 .toggle-all-btn {
-	margin-right: 1em;
-	padding: 0.2em 0.5em;
-	border-radius: 4px;
-	border: 1px solid #666;
-	background: #333;
-	color: #ddd;
-	cursor: pointer;
-	font-size: 0.9em;
+        margin-right: 1em;
+        padding: 0.2em 0.5em;
+        border-radius: 4px;
+        border: 1px solid #666;
+        background: #333;
+        color: #ddd;
+        cursor: pointer;
+        font-size: 0.9em;
+}
+
+#result-info {
+        padding: 0 2em;
+        margin: 0.5em 0;
+        font-size: 0.9em;
 }
 
 .share-btn {


### PR DESCRIPTION
## Summary
- show the result count above the monster list
- style for the new result-info section
- update JS to compute and display counts
- update pagination logic to refresh counts after filtering or scrolling

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68440393d038832b8a92afd137d19ff6